### PR TITLE
trace: optimize start and end config

### DIFF
--- a/trace/span.go
+++ b/trace/span.go
@@ -48,11 +48,14 @@ type spanEndConfig struct {
 	endTime epoch.Nanos
 }
 
-type SpanEndOption func(*spanEndConfig)
+type SpanEndOption func(spanEndConfig) spanEndConfig
 
 // WithEndTime sets the end time of the span.
 func WithEndTime(t time.Time) SpanEndOption {
-	return func(cfg *spanEndConfig) { cfg.endTime = epoch.NewNanos(t) }
+	return func(cfg spanEndConfig) spanEndConfig {
+		cfg.endTime = epoch.NewNanos(t)
+		return cfg
+	}
 }
 
 // End signals the span has ended.
@@ -63,7 +66,7 @@ func (s *Span) End(opts ...SpanEndOption) {
 	}
 	cfg := spanEndConfig{}
 	for _, opt := range opts {
-		opt(&cfg)
+		cfg = opt(cfg)
 	}
 	if cfg.endTime == 0 {
 		cfg.endTime = epoch.NanosNow()

--- a/trace/span_test.go
+++ b/trace/span_test.go
@@ -70,3 +70,13 @@ func TestSpan_End_Race(t *testing.T) {
 		t.Errorf("Span.IsRecording() should return false after End() was called")
 	}
 }
+
+func BenchmarkStartEndSpan(b *testing.B) {
+	tr := &trace.Tracer{}
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, span := tr.Start(ctx, "test-span")
+		span.End()
+	}
+}

--- a/trace/tracer.go
+++ b/trace/tracer.go
@@ -13,17 +13,20 @@ type startConfig struct {
 	startTime epoch.Nanos
 }
 
-type SpanStartOption func(*startConfig)
+type SpanStartOption func(startConfig) startConfig
 
 func WithStartTime(t time.Time) SpanStartOption {
-	return func(cfg *startConfig) { cfg.startTime = epoch.NewNanos(t) }
+	return func(cfg startConfig) startConfig {
+		cfg.startTime = epoch.NewNanos(t)
+		return cfg
+	}
 }
 
 // Start starts a Span and returns a new context containing the Span.
 func (t *Tracer) Start(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, *Span) {
 	cfg := startConfig{}
 	for _, opt := range opts {
-		opt(&cfg)
+		cfg = opt(cfg)
 	}
 	if cfg.startTime == 0 {
 		cfg.startTime = epoch.NanosNow()


### PR DESCRIPTION
Pass struct instead of pointers. Otherwise, Go allocates 8 bytes each for the start and end config.