### PR TITLE
trace: use go linkname to runtime.nanotime

### DIFF
--- a/internal/epoch/nanos.go
+++ b/internal/epoch/nanos.go
@@ -3,6 +3,7 @@ package epoch
 import (
 	"sync/atomic"
 	"time"
+	_ "unsafe"
 )
 
 // Nanos is the nanoseconds since the Unix epoch.
@@ -14,7 +15,9 @@ type Nanos int64
 func NewNanos(t time.Time) Nanos { return Nanos(t.UnixNano()) }
 
 // NanosNow returns the current time in nanoseconds since the epoch.
-func NanosNow() Nanos { return Nanos(time.Now().UnixNano()) }
+//
+//go:nosplit
+func NanosNow() Nanos { return Nanos(nanotime()) }
 
 // ToTime converts the Nanos to a time.Time. If the value is zero, it
 // returns the zero-value of time.Time.
@@ -40,3 +43,7 @@ func (u *Nanos) SwapIfZero(ns Nanos) bool {
 func (u *Nanos) Load() Nanos {
 	return Nanos(atomic.LoadInt64((*int64)(u)))
 }
+
+//go:linkname nanotime runtime.nanotime
+//go:noescape
+func nanotime() int64

--- a/private/.gitignore
+++ b/private/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything except the ignore file and README.
+*
+!/.gitignore


### PR DESCRIPTION
Decreases runtime by 41% from 83 to 49 ns.

```sh
# Benchmark baseline.
go test -bench '^\QBenchmarkStartEndSpan\E$' -run '^$' -count=10 ./trace | tee private/old.txt

# Benchmark new changes.
go test -bench '^\QBenchmarkStartEndSpan\E$' -run '^$' -count=10 ./trace | tee private/new.txt

# Compare benchmarks.
benchstat private/{old,new}.txt

goos: darwin
goarch: arm64
pkg: github.com/jschaf/observe/trace
cpu: Apple M2 Max
                │ private/old.txt │           private/new.txt           │
                │     sec/op      │   sec/op     vs base                │
StartEndSpan-12       83.08n ± 1%   48.88n ± 4%  -41.16% (p=0.000 n=10)

                │ private/old.txt │        private/new.txt         │
                │      B/op       │    B/op     vs base            │
StartEndSpan-12        48.00 ± 0%   48.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                │ private/old.txt │        private/new.txt         │
                │    allocs/op    │ allocs/op   vs base            │
StartEndSpan-12        1.000 ± 0%   1.000 ± 0%  ~ (p=1.000 n=10)
```