### PR TITLE
trace: optimize span id parsing

### DIFF
--- a/internal/hextbl/hex.go
+++ b/internal/hextbl/hex.go
@@ -1,5 +1,7 @@
 package hextbl
 
+import "math"
+
 //goland:noinspection SpellCheckingInspection
 const (
 	Lookup  = "0123456789abcdef"
@@ -8,7 +10,7 @@ const (
 		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
 		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
 		"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xff\xff\xff\xff\xff\xff" +
-		"\xff\x0a\x0b\x0c\x0d\x0e\x0f\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
 		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
 		"\xff\x0a\x0b\x0c\x0d\x0e\x0f\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
 		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
@@ -22,7 +24,33 @@ const (
 		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
 )
 
-// ReadByte reads two hex characters and returns the byte value and if the hex
+const invalidReverse = math.MaxUint64
+
+func shiftReverseTable(shift int) [256]uint64 {
+	var table [256]uint64
+	for i := range Reverse {
+		if Reverse[i] == 0xff {
+			table[i] = invalidReverse
+			continue
+		}
+		table[i] = uint64(Reverse[i]) << shift
+	}
+	return table
+}
+
+// reverseDigit0 is the first digit in a 4-byte hex string.
+var reverseDigit0 = shiftReverseTable(12) //nolint:gochecknoglobals
+
+// reverseDigit1 is the second digit in a 4-byte hex string.
+var reverseDigit1 = shiftReverseTable(8) //nolint:gochecknoglobals
+
+// reverseDigit2 is the third digit in a 4-byte hex string.
+var reverseDigit2 = shiftReverseTable(4) //nolint:gochecknoglobals
+
+// reverseDigit3 is the last digit in a 4-byte hex string.
+var reverseDigit3 = shiftReverseTable(0) //nolint:gochecknoglobals
+
+// ReadByte reads two hex characters and returns the byte value, and if the hex
 // characters were valid.
 func ReadByte(a, b byte) (byte, bool) {
 	x := Reverse[a]
@@ -34,25 +62,23 @@ func ReadByte(a, b byte) (byte, bool) {
 	return (x << 4) | y, true
 }
 
-// ParseUint64 parses a 16-byte hex string into a uint64.
-func ParseUint64(s string) (uint64, bool) {
+// ParseUint64 parses a 16-byte hex string into a uint64. Returns 0 if the
+// string is not valid. All zeros are not a valid Span ID.
+func ParseUint64(s string) uint64 {
 	if len(s) != 16 {
-		return 0, false
+		return 0
 	}
-	var n uint64
-	invalidMark := byte(0)
-	for i := 0; i < len(s); i += 4 {
-		shift := uint((15 - i) * 4) //nolint:gosec
-		n |= uint64(Reverse[s[i]]) << shift
-		n |= uint64(Reverse[s[i+1]]) << (shift - 4)
-		n |= uint64(Reverse[s[i+2]]) << (shift - 8)
-		n |= uint64(Reverse[s[i+3]]) << (shift - 12)
-		invalidMark |= Reverse[s[i]] | Reverse[s[i+1]] | Reverse[s[i+2]] | Reverse[s[i+3]]
+
+	n0 := reverseDigit0[s[0x0]] | reverseDigit1[s[0x1]] | reverseDigit2[s[0x2]] | reverseDigit3[s[0x3]]
+	n1 := reverseDigit0[s[0x4]] | reverseDigit1[s[0x5]] | reverseDigit2[s[0x6]] | reverseDigit3[s[0x7]]
+	n2 := reverseDigit0[s[0x8]] | reverseDigit1[s[0x9]] | reverseDigit2[s[0xa]] | reverseDigit3[s[0xb]]
+	n3 := reverseDigit0[s[0xc]] | reverseDigit1[s[0xd]] | reverseDigit2[s[0xe]] | reverseDigit3[s[0xf]]
+
+	invalid := (n0&invalidReverse | n1&invalidReverse | n2&invalidReverse | n3&invalidReverse) == invalidReverse
+	if invalid {
+		return 0
 	}
-	if invalidMark&0xf0 != 0 {
-		return 0, false
-	}
-	return n, true
+	return (n0 << 48) | (n1 << 32) | (n2 << 16) | n3
 }
 
 // Uint64Bytes converts a uint64 to a 16-byte hex array.

--- a/internal/hextbl/hex_test.go
+++ b/internal/hextbl/hex_test.go
@@ -1,6 +1,8 @@
 package hextbl_test
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/jschaf/observe/internal/difftest"
@@ -43,28 +45,46 @@ func TestParseUint64(t *testing.T) {
 		wantOk bool
 	}{
 		{
-			name:   "zero",
-			in:     "0000000000000000",
-			want:   0,
-			wantOk: true,
-		},
-		{
 			name:   "filled",
 			in:     "0123456789abcdef",
 			want:   0x0123456789ABCDEF,
 			wantOk: true,
 		},
 		{
-			name:   "filled uppercase",
-			in:     "0123456789ABCDEF",
-			want:   0x0123456789ABCDEF,
+			name:   "single max byte",
+			in:     "ff00000000000000",
+			want:   0xFF00000000000000,
 			wantOk: true,
 		},
 
 		// Invalid
 		{
+			name:   "zero",
+			in:     "0000000000000000",
+			want:   0,
+			wantOk: false,
+		},
+		{
 			name:   "invalid length short",
 			in:     "abc",
+			want:   0,
+			wantOk: false,
+		},
+		{
+			name:   "filled uppercase",
+			in:     "0123456789ABCDEF",
+			want:   0,
+			wantOk: false,
+		},
+		{
+			name:   "single uppercase",
+			in:     "0000A00000000000",
+			want:   0,
+			wantOk: false,
+		},
+		{
+			name:   "two uppercase",
+			in:     "FF00000000000000",
 			want:   0,
 			wantOk: false,
 		},
@@ -84,15 +104,51 @@ func TestParseUint64(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := hextbl.ParseUint64(tt.in)
+			got := hextbl.ParseUint64(tt.in)
 			if got != tt.want {
-				t.Errorf("ParseUint64(%q) = %v, want %v", tt.in, got, tt.want)
-			}
-			if ok != tt.wantOk {
-				t.Errorf("ParseUint64(%q).ok = %v, want %v", tt.in, ok, tt.wantOk)
+				t.Errorf("ParseUint64Table(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}
+}
+
+func FuzzParseUint64(f *testing.F) {
+	f.Add("0123456789abcdef")
+	f.Add(strings.Repeat("0", 16))
+	f.Add(strings.Repeat("f", 16))
+	f.Fuzz(func(t *testing.T, s string) {
+		slow := slowParseUint64(s)
+		fast := hextbl.ParseUint64(s)
+		if slow != fast {
+			t.Errorf("ParseUint64(%q) = %x, want %x", s, fast, slow)
+		}
+	})
+}
+
+func slowParseUint64(s string) uint64 {
+	if len(s) != 16 {
+		return 0
+	}
+	// Return false for uppercase hex.
+	for _, ch := range s {
+		if ch >= 'A' && ch <= 'F' {
+			return 0
+		}
+	}
+	bs, err := hex.DecodeString(s)
+	if err != nil {
+		return 0
+	}
+	if len(bs) != 8 {
+		return 0
+	}
+	// Convert to uint64.
+	var n uint64
+	for _, b := range bs {
+		n <<= 8
+		n |= uint64(b)
+	}
+	return n
 }
 
 func TestUint64Bytes(t *testing.T) {
@@ -120,4 +176,29 @@ func TestUint64Bytes(t *testing.T) {
 			difftest.AssertSame(t, "Uint64Bytes mismatch", tt.want, gotStr)
 		})
 	}
+}
+
+// Results as of 2025-05-23.
+//
+//	BenchmarkParseUint64/ParseUint64      318850330   3.68 ns/op  0 B/op  0 allocs/op
+//	BenchmarkParseUint64/hex.DecodeString  69341446  16.55 ns/op  8 B/op  1 allocs/op
+func BenchmarkParseUint64(b *testing.B) {
+	b.Run("ParseUint64", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			n := hextbl.ParseUint64("0123456789abcdef")
+			if n != 0x0123456789ABCDEF {
+				b.Fatalf("ParseUint64Table() = %v, want %v", n, 0x0123456789ABCDEF)
+			}
+		}
+	})
+	b.Run("hex.DecodeString", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_, err := hex.DecodeString("0123456789abcdef")
+			if err != nil {
+				b.Fatalf("ParseUint64() invalid")
+			}
+		}
+	})
 }

--- a/internal/hextbl/uint128_test.go
+++ b/internal/hextbl/uint128_test.go
@@ -37,12 +37,6 @@ func TestParseUint128(t *testing.T) {
 			want:   hextbl.Uint128{Hi: 0x0123456789abcdef, Lo: 0x0123456789abcdef},
 			wantOk: true,
 		},
-		{
-			name:   "filled uppercase",
-			in:     "0123456789ABCDEF0123456789ABCDEF",
-			want:   hextbl.Uint128{Hi: 0x0123456789abcdef, Lo: 0x0123456789abcdef},
-			wantOk: true,
-		},
 
 		// Invalid
 		{
@@ -61,6 +55,12 @@ func TestParseUint128(t *testing.T) {
 			name:   "invalid char",
 			in:     "z123456789abcdef0123456789abcdef",
 			want:   hextbl.Uint128{},
+			wantOk: false,
+		},
+		{
+			name:   "filled uppercase",
+			in:     "0123456789ABCDEF0123456789ABCDEF",
+			want:   hextbl.Uint128{Hi: 0, Lo: 0},
 			wantOk: false,
 		},
 	}

--- a/trace/id.go
+++ b/trace/id.go
@@ -64,8 +64,8 @@ func ParseTraceID(s string) (TraceID, error) {
 
 // ParseSpanID parses a 16-character hex string into a SpanID.
 func ParseSpanID(s string) (SpanID, error) {
-	n, ok := hextbl.ParseUint64(s)
-	if !ok {
+	n := hextbl.ParseUint64(s)
+	if n == 0 {
 		return SpanID{}, fmt.Errorf("invalid hex span ID: %s", s)
 	}
 	return SpanID{n: n}, nil

--- a/trace/id_test.go
+++ b/trace/id_test.go
@@ -60,13 +60,13 @@ func TestParseTraceID_Roundtrip(t *testing.T) {
 		},
 		{
 			name:  "Hi only",
-			input: "deadBeefCafe00010000000000000000",
-			want:  newTraceID(0xdeadbeefcafe0001, 0),
+			input: "dead1234cafe00010000000000000000",
+			want:  newTraceID(0xdead1234cafe0001, 0),
 		},
 		{
 			name:  "Lo only",
-			input: "0000000000000000deadBeefCafe0001",
-			want:  newTraceID(0, 0xdeadbeefcafe0001),
+			input: "0000000000000000dead1234cafe0001",
+			want:  newTraceID(0, 0xdead1234cafe0001),
 		},
 		{
 			name:  "Leading zeros in hi",
@@ -82,11 +82,6 @@ func TestParseTraceID_Roundtrip(t *testing.T) {
 			name:  "Max values",
 			input: strings.Repeat("f", 32),
 			want:  newTraceID(math.MaxUint64, math.MaxUint64),
-		},
-		{
-			name:  "Uppercase Hex",
-			input: "0123456789ABCDEF1ED2BA9876543210",
-			want:  newTraceID(0x0123456789ABCDEF, 0x1ED2BA9876543210),
 		},
 	}
 
@@ -192,11 +187,6 @@ func TestParseSpanID_Roundtrip(t *testing.T) {
 			name:  "Max value",
 			input: strings.Repeat("f", 16),
 			want:  SpanID{n: math.MaxUint64},
-		},
-		{
-			name:  "Uppercase Hex",
-			input: "0123456789ABCDEF",
-			want:  SpanID{n: 0x0123456789ABCDEF},
 		},
 	}
 

--- a/trace/propagate/http_header_test.go
+++ b/trace/propagate/http_header_test.go
@@ -55,13 +55,6 @@ func TestHTTPHeader_ExtractContext(t *testing.T) {
 			},
 		},
 		{
-			name:        "valid uppercase",
-			traceparent: "00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01",
-			want: http.Header{
-				headerTraceparent: []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
-			},
-		},
-		{
 			name:        "valid not sampled",
 			traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
 			want: http.Header{
@@ -105,6 +98,11 @@ func TestHTTPHeader_ExtractContext(t *testing.T) {
 			want: http.Header{
 				headerTraceparent: []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 			},
+		},
+		{
+			name:        "invalid uppercase",
+			traceparent: "00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01",
+			want:        http.Header{},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Decreases runtime by about 2.6x (9.5 ns to 3.7 ns) for parsing the 16-char hex string.

```sh
BenchmarkParseUint64
BenchmarkParseUint64/ParseUint64Table
BenchmarkParseUint64/ParseUint64Table-12         	318850330	         3.686 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseUint64/ParseUint64
BenchmarkParseUint64/ParseUint64-12              	126126168	         9.553 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseUint64/hex.DecodeString
BenchmarkParseUint64/hex.DecodeString-12         	69341446	        16.55 ns/op	       8 B/op	       1 allocs/op
```