### PR TITLE
trace: optimize trace id parsing

### DIFF
--- a/internal/hextbl/hex_test.go
+++ b/internal/hextbl/hex_test.go
@@ -39,66 +39,56 @@ func TestReadByte(t *testing.T) {
 
 func TestParseUint64(t *testing.T) {
 	tests := []struct {
-		name   string
-		in     string
-		want   uint64
-		wantOk bool
+		name string
+		in   string
+		want uint64
 	}{
 		{
-			name:   "filled",
-			in:     "0123456789abcdef",
-			want:   0x0123456789ABCDEF,
-			wantOk: true,
+			name: "filled",
+			in:   "0123456789abcdef",
+			want: 0x0123456789ABCDEF,
 		},
 		{
-			name:   "single max byte",
-			in:     "ff00000000000000",
-			want:   0xFF00000000000000,
-			wantOk: true,
+			name: "single max byte",
+			in:   "ff00000000000000",
+			want: 0xFF00000000000000,
 		},
 
 		// Invalid
 		{
-			name:   "zero",
-			in:     "0000000000000000",
-			want:   0,
-			wantOk: false,
+			name: "zero",
+			in:   "0000000000000000",
+			want: 0,
 		},
 		{
-			name:   "invalid length short",
-			in:     "abc",
-			want:   0,
-			wantOk: false,
+			name: "invalid length short",
+			in:   "abc",
+			want: 0,
 		},
 		{
-			name:   "filled uppercase",
-			in:     "0123456789ABCDEF",
-			want:   0,
-			wantOk: false,
+			name: "filled uppercase",
+			in:   "0123456789ABCDEF",
+			want: 0,
 		},
 		{
-			name:   "single uppercase",
-			in:     "0000A00000000000",
-			want:   0,
-			wantOk: false,
+			name: "single uppercase",
+			in:   "0000A00000000000",
+			want: 0,
 		},
 		{
-			name:   "two uppercase",
-			in:     "FF00000000000000",
-			want:   0,
-			wantOk: false,
+			name: "two uppercase",
+			in:   "FF00000000000000",
+			want: 0,
 		},
 		{
-			name:   "invalid length long",
-			in:     "0123456789abcdef0",
-			want:   0,
-			wantOk: false,
+			name: "invalid length long",
+			in:   "0123456789abcdef0",
+			want: 0,
 		},
 		{
-			name:   "invalid char",
-			in:     "z123456789abcdef",
-			want:   0,
-			wantOk: false,
+			name: "invalid char",
+			in:   "z123456789abcdef",
+			want: 0,
 		},
 	}
 
@@ -106,7 +96,7 @@ func TestParseUint64(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := hextbl.ParseUint64(tt.in)
 			if got != tt.want {
-				t.Errorf("ParseUint64Table(%q) = %v, want %v", tt.in, got, tt.want)
+				t.Errorf("ParseUint64(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}
@@ -137,9 +127,6 @@ func slowParseUint64(s string) uint64 {
 	}
 	bs, err := hex.DecodeString(s)
 	if err != nil {
-		return 0
-	}
-	if len(bs) != 8 {
 		return 0
 	}
 	// Convert to uint64.
@@ -188,7 +175,7 @@ func BenchmarkParseUint64(b *testing.B) {
 		for b.Loop() {
 			n := hextbl.ParseUint64("0123456789abcdef")
 			if n != 0x0123456789ABCDEF {
-				b.Fatalf("ParseUint64Table() = %v, want %v", n, 0x0123456789ABCDEF)
+				b.Fatalf("ParseUint64() = %v, want %v", n, 0x0123456789ABCDEF)
 			}
 		}
 	})
@@ -197,7 +184,7 @@ func BenchmarkParseUint64(b *testing.B) {
 		for b.Loop() {
 			_, err := hex.DecodeString("0123456789abcdef")
 			if err != nil {
-				b.Fatalf("ParseUint64() invalid")
+				b.Fatalf("decode hex: %v", err)
 			}
 		}
 	})

--- a/internal/hextbl/uint128.go
+++ b/internal/hextbl/uint128.go
@@ -14,32 +14,30 @@ type Uint128 struct {
 }
 
 // ParseUint128 parses a 32-byte hex string to Uint128.
-func ParseUint128(s string) (Uint128, bool) {
+func ParseUint128(s string) Uint128 {
 	if len(s) != 32 {
-		return Uint128{}, false
+		return Uint128{}
 	}
-	var hi, lo uint64
-	invalidMark := byte(0)
-	for i := 0; i < 16; i += 4 {
-		shift := uint((15 - i) * 4) //nolint:gosec
 
-		hi |= uint64(Reverse[s[i]]) << shift
-		hi |= uint64(Reverse[s[i+1]]) << (shift - 4)
-		hi |= uint64(Reverse[s[i+2]]) << (shift - 8)
-		hi |= uint64(Reverse[s[i+3]]) << (shift - 12)
+	hi0 := reverseDigit0[s[0x0]] | reverseDigit1[s[0x1]] | reverseDigit2[s[0x2]] | reverseDigit3[s[0x3]]
+	hi1 := reverseDigit0[s[0x4]] | reverseDigit1[s[0x5]] | reverseDigit2[s[0x6]] | reverseDigit3[s[0x7]]
+	hi2 := reverseDigit0[s[0x8]] | reverseDigit1[s[0x9]] | reverseDigit2[s[0xa]] | reverseDigit3[s[0xb]]
+	hi3 := reverseDigit0[s[0xc]] | reverseDigit1[s[0xd]] | reverseDigit2[s[0xe]] | reverseDigit3[s[0xf]]
 
-		lo |= uint64(Reverse[s[16+i]]) << shift
-		lo |= uint64(Reverse[s[16+i+1]]) << (shift - 4)
-		lo |= uint64(Reverse[s[16+i+2]]) << (shift - 8)
-		lo |= uint64(Reverse[s[16+i+3]]) << (shift - 12)
+	lo0 := reverseDigit0[s[0x10]] | reverseDigit1[s[0x11]] | reverseDigit2[s[0x12]] | reverseDigit3[s[0x13]]
+	lo1 := reverseDigit0[s[0x14]] | reverseDigit1[s[0x15]] | reverseDigit2[s[0x16]] | reverseDigit3[s[0x17]]
+	lo2 := reverseDigit0[s[0x18]] | reverseDigit1[s[0x19]] | reverseDigit2[s[0x1a]] | reverseDigit3[s[0x1b]]
+	lo3 := reverseDigit0[s[0x1c]] | reverseDigit1[s[0x1d]] | reverseDigit2[s[0x1e]] | reverseDigit3[s[0x1f]]
 
-		invalidMark |= Reverse[s[i]] | Reverse[s[i+1]] | Reverse[s[i+2]] | Reverse[s[i+3]]
-		invalidMark |= Reverse[s[16+i]] | Reverse[s[16+i+1]] | Reverse[s[16+i+2]] | Reverse[s[16+i+3]]
+	hiInvalid := (hi0&invalidReverse | hi1&invalidReverse | hi2&invalidReverse | hi3&invalidReverse) == invalidReverse
+	loInvalid := (lo0&invalidReverse | lo1&invalidReverse | lo2&invalidReverse | lo3&invalidReverse) == invalidReverse
+	if hiInvalid || loInvalid {
+		return Uint128{}
 	}
-	if invalidMark&0xf0 != 0 {
-		return Uint128{}, false
-	}
-	return Uint128{Hi: hi, Lo: lo}, true
+
+	hi := (hi0 << 48) | (hi1 << 32) | (hi2 << 16) | hi3
+	lo := (lo0 << 48) | (lo1 << 32) | (lo2 << 16) | lo3
+	return Uint128{Hi: hi, Lo: lo}
 }
 
 // IsZero reports whether u == 0.

--- a/internal/hextbl/uint128_test.go
+++ b/internal/hextbl/uint128_test.go
@@ -1,6 +1,8 @@
 package hextbl_test
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/jschaf/observe/internal/hextbl"
@@ -8,71 +10,59 @@ import (
 
 func TestParseUint128(t *testing.T) {
 	tests := []struct {
-		name   string
-		in     string
-		want   hextbl.Uint128
-		wantOk bool
+		name string
+		in   string
+		want hextbl.Uint128
 	}{
 		{
-			name:   "zero",
-			in:     "00000000000000000000000000000000",
-			want:   hextbl.Uint128{},
-			wantOk: true,
+			name: "zero",
+			in:   "00000000000000000000000000000000",
+			want: hextbl.Uint128{},
 		},
 		{
-			name:   "non-zero hi",
-			in:     "0123456789abcdef0000000000000000",
-			want:   hextbl.Uint128{Hi: 0x0123456789ABCDEF},
-			wantOk: true,
+			name: "non-zero hi",
+			in:   "0123456789abcdef0000000000000000",
+			want: hextbl.Uint128{Hi: 0x0123456789ABCDEF},
 		},
 		{
-			name:   "non-zero lo",
-			in:     "00000000000000000123456789abcdef",
-			want:   hextbl.Uint128{Lo: 0x0123456789ABCDEF},
-			wantOk: true,
+			name: "non-zero lo",
+			in:   "00000000000000000123456789abcdef",
+			want: hextbl.Uint128{Lo: 0x0123456789ABCDEF},
 		},
 		{
-			name:   "filled",
-			in:     "0123456789abcdef0123456789abcdef",
-			want:   hextbl.Uint128{Hi: 0x0123456789abcdef, Lo: 0x0123456789abcdef},
-			wantOk: true,
+			name: "filled",
+			in:   "0123456789abcdef0123456789abcdef",
+			want: hextbl.Uint128{Hi: 0x0123456789abcdef, Lo: 0x0123456789abcdef},
 		},
 
 		// Invalid
 		{
-			name:   "invalid length short",
-			in:     "abc",
-			want:   hextbl.Uint128{},
-			wantOk: false,
+			name: "invalid length short",
+			in:   "abc",
+			want: hextbl.Uint128{},
 		},
 		{
-			name:   "invalid length long",
-			in:     "0123456789abcdef0123456789abcdef1",
-			want:   hextbl.Uint128{},
-			wantOk: false,
+			name: "invalid length long",
+			in:   "0123456789abcdef0123456789abcdef1",
+			want: hextbl.Uint128{},
 		},
 		{
-			name:   "invalid char",
-			in:     "z123456789abcdef0123456789abcdef",
-			want:   hextbl.Uint128{},
-			wantOk: false,
+			name: "invalid char",
+			in:   "z123456789abcdef0123456789abcdef",
+			want: hextbl.Uint128{},
 		},
 		{
-			name:   "filled uppercase",
-			in:     "0123456789ABCDEF0123456789ABCDEF",
-			want:   hextbl.Uint128{Hi: 0, Lo: 0},
-			wantOk: false,
+			name: "filled uppercase",
+			in:   "0123456789ABCDEF0123456789ABCDEF",
+			want: hextbl.Uint128{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := hextbl.ParseUint128(tt.in)
+			got := hextbl.ParseUint128(tt.in)
 			if got != tt.want {
 				t.Errorf("ParseUint128(%q) = %v, want %v", tt.in, got, tt.want)
-			}
-			if ok != tt.wantOk {
-				t.Errorf("ParseUint128(%q) = %v, want %v", tt.in, ok, tt.wantOk)
 			}
 		})
 	}
@@ -134,4 +124,70 @@ func TestUint128_Bytes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzParseUint128(f *testing.F) {
+	f.Add("0123456789abcdef")
+	f.Add(strings.Repeat("0", 16))
+	f.Add(strings.Repeat("f", 16))
+	f.Fuzz(func(t *testing.T, s string) {
+		slow := slowParseUint128(s)
+		fast := hextbl.ParseUint128(s)
+		if slow != fast {
+			t.Errorf("ParseUint128(%q) = %v, want %v", s, fast, slow)
+		}
+	})
+}
+
+func slowParseUint128(s string) hextbl.Uint128 {
+	if len(s) != 32 {
+		return hextbl.Uint128{}
+	}
+	// Return 0 for uppercase hex.
+	for _, ch := range s {
+		if ch >= 'A' && ch <= 'F' {
+			return hextbl.Uint128{}
+		}
+	}
+	bs, err := hex.DecodeString(s)
+	if err != nil {
+		return hextbl.Uint128{}
+	}
+	// Convert to uint64.
+	var hi uint64
+	for _, b := range bs[:8] {
+		hi <<= 8
+		hi |= uint64(b)
+	}
+	var lo uint64
+	for _, b := range bs[8:] {
+		lo <<= 8
+		lo |= uint64(b)
+	}
+	return hextbl.Uint128{Hi: hi, Lo: lo}
+}
+
+// Results as of 2025-05-23.
+//
+//	BenchmarkParseUint12/ParseUint128      168090454	  7.10 ns/op   0 B/op  0 allocs/op
+//	BenchmarkParseUint12/hex.DecodeString   44913612  25.40 ns/op  16 B/op  1 allocs/op
+func BenchmarkParseUint12(b *testing.B) {
+	b.Run("ParseUint128", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			n := hextbl.ParseUint128("0123456789abcdef0123456789abcdef")
+			if n != (hextbl.Uint128{Hi: 0x0123456789abcdef, Lo: 0x0123456789abcdef}) {
+				b.Fatalf("ParseUint128() = %v, want %v", n, "0x0123456789abcdef0123456789abcdef")
+			}
+		}
+	})
+	b.Run("hex.DecodeString", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_, err := hex.DecodeString("0123456789abcdef0123456789abcdef")
+			if err != nil {
+				b.Fatalf("decode hex: %v", err)
+			}
+		}
+	})
 }

--- a/trace/id.go
+++ b/trace/id.go
@@ -55,8 +55,8 @@ func genSpanID() SpanID {
 
 // ParseTraceID parses a 32-character hex string into a TraceID.
 func ParseTraceID(s string) (TraceID, error) {
-	n, ok := hextbl.ParseUint128(s)
-	if !ok {
+	n := hextbl.ParseUint128(s)
+	if n.IsZero() {
 		return TraceID{}, fmt.Errorf("invalid hex trace ID: %s", s)
 	}
 	return TraceID{n: n}, nil


### PR DESCRIPTION
Decreases runtime by about 1.5x (11.4 ns to 7.1 ns) for parsing the 32-char hex string.
