### PR TITLE
trace: minimize tracer.startSpan allocations

### DIFF
--- a/internal/hextbl/hex.go
+++ b/internal/hextbl/hex.go
@@ -62,8 +62,8 @@ func ReadByte(a, b byte) (byte, bool) {
 	return (x << 4) | y, true
 }
 
-// ParseUint64 parses a 16-byte hex string into a uint64. Returns 0 if the
-// string is not valid. All zeros are not a valid Span ID.
+// ParseUint64 parses a 16-byte lower-case hex string into a uint64. Returns 0
+// if the string is not valid. All zeros are not a valid Span ID.
 func ParseUint64(s string) uint64 {
 	if len(s) != 16 {
 		return 0

--- a/internal/hextbl/uint128.go
+++ b/internal/hextbl/uint128.go
@@ -13,7 +13,8 @@ type Uint128 struct {
 	Lo uint64
 }
 
-// ParseUint128 parses a 32-byte hex string to Uint128.
+// ParseUint128 parses a 32-byte lower-case hex string to Uint128. Returns 0 if
+// the hex string is not valid. All zeros are not a valid Trace ID.
 func ParseUint128(s string) Uint128 {
 	if len(s) != 32 {
 		return Uint128{}

--- a/trace/tracer.go
+++ b/trace/tracer.go
@@ -23,7 +23,7 @@ func WithStartTime(t time.Time) SpanStartOption {
 }
 
 // Start starts a Span and returns a new context containing the Span.
-func (t *Tracer) Start(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, *Span) {
+func (t *Tracer) Start(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, Span) {
 	cfg := startConfig{}
 	for _, opt := range opts {
 		cfg = opt(cfg)
@@ -32,10 +32,11 @@ func (t *Tracer) Start(ctx context.Context, name string, opts ...SpanStartOption
 		cfg.startTime = epoch.NanosNow()
 	}
 
-	span := &Span{
+	span := Span{
 		name:   name,
 		tracer: t,
 		start:  cfg.startTime,
+		end:    new(epoch.Nanos),
 	}
 
 	return ctx, span

--- a/trace/tracer_test.go
+++ b/trace/tracer_test.go
@@ -39,7 +39,7 @@ func TestTracer_Start(t *testing.T) {
 	})
 }
 
-func startTestSpan(t *testing.T, opts ...trace.SpanStartOption) *trace.Span {
+func startTestSpan(t *testing.T, opts ...trace.SpanStartOption) trace.Span {
 	t.Helper()
 	tr := &trace.Tracer{}
 	ctx := t.Context()


### PR DESCRIPTION
The only mutable attribute is the end time, so pass the span by value and make the end time a pointer. Provides a 9% speed-up and reduces allocation per span from 48 bytes to 8 bytes.

```
BenchmarkStartEndSpan-12    	24594645	        48.56 ns/op	      48 B/op	       1 allocs/op
BenchmarkStartEndSpan-12    	26664096	        44.61 ns/op	       8 B/op	       1 allocs/op
```