### PR TITLE
trace: add attrs implementation

### DIFF
--- a/internal/difftest/assert_same.go
+++ b/internal/difftest/assert_same.go
@@ -18,6 +18,8 @@ func AssertSame[T any](t *testing.T, msg string, want, got T) {
 //golint:ignore:asciicheck
 func diff(a, b any) string {
 	switch x := a.(type) {
+	case bool, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64:
+		return diffString(fmt.Sprint(a), fmt.Sprint(b))
 	case string:
 		y, _ := b.(string)
 		return diffString(x, y)

--- a/trace/attr.go
+++ b/trace/attr.go
@@ -1,0 +1,36 @@
+package trace
+
+// An Attr is a key-value pair.
+type Attr struct {
+	Key   string
+	Value Value
+}
+
+// Bool returns an Attr for a bool.
+func Bool(key string, value bool) Attr {
+	return Attr{key, boolValue(value)}
+}
+
+// Float64 returns an Attr for a floating-point number.
+func Float64(key string, value float64) Attr {
+	return Attr{key, float64Value(value)}
+}
+
+// Int64 returns an Attr for an int64.
+func Int64(key string, value int64) Attr {
+	return Attr{key, int64Value(value)}
+}
+
+// Int converts an int to an int64 and returns an Attr with that value.
+func Int(key string, value int) Attr {
+	return Attr{key, int64Value(int64(value))}
+}
+
+// String returns an Attr for a string value.
+func String(key, value string) Attr {
+	return Attr{key, stringValue(value)}
+}
+
+func (a Attr) String() string {
+	return a.Key + "=" + a.Value.String()
+}

--- a/trace/attr_test.go
+++ b/trace/attr_test.go
@@ -1,0 +1,145 @@
+package trace
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/jschaf/observe/internal/difftest"
+)
+
+func TestAttr_RoundTrip(t *testing.T) {
+	assertRoundTrip(t, "bool", true)
+	assertRoundTrip(t, "bool", false)
+
+	assertRoundTrip(t, "float64", -1999999999.0)
+	assertRoundTrip(t, "float64", -1.0)
+	assertRoundTrip(t, "float64", 0.0)
+	assertRoundTrip(t, "float64", math.MaxFloat64)
+
+	assertRoundTrip(t, "int", math.MaxInt)
+	assertRoundTrip(t, "int", 0)
+	assertRoundTrip(t, "int", -1)
+
+	assertRoundTrip(t, "int64", int64(math.MaxInt))
+
+	assertRoundTrip(t, "string", "")
+	assertRoundTrip(t, "string", "string-value")
+}
+
+func assertRoundTrip(t *testing.T, key string, val any) {
+	t.Helper()
+	var attr Attr
+	switch v := val.(type) {
+	case bool:
+		attr = Bool(key, v)
+		difftest.AssertSame(t, "round trip value bool", v, attr.Value.Bool())
+	case int:
+		attr = Int(key, v)
+		difftest.AssertSame(t, "round trip value int", int64(v), attr.Value.Int64())
+	case int64:
+		attr = Int64(key, v)
+		difftest.AssertSame(t, "round trip value int64", v, attr.Value.Int64())
+	case float64:
+		attr = Float64(key, v)
+		difftest.AssertSame(t, "round trip value float64", v, attr.Value.Float64())
+	case string:
+		attr = String(key, v)
+		difftest.AssertSame(t, "round trip value string", v, attr.Value.String())
+	default:
+		t.Fatalf("unsupported type %T for key %s", v, key)
+	}
+	msg := fmt.Sprintf("round trip %s=%v", key, val)
+	wantAttrStr := key + "=" + fmt.Sprint(val)
+	gotAttrStr := attr.String()
+	difftest.AssertSame(t, msg, wantAttrStr, gotAttrStr)
+}
+
+func TestAttr_NoAlloc(t *testing.T) {
+	// Assign values just to make sure the compiler doesn't optimize away the
+	// statements.
+	var (
+		b bool
+		f float64
+		i int64
+		s string
+	)
+	a := int(testing.AllocsPerRun(5, func() {
+		b = Bool("key", true).Value.Bool()
+		f = Float64("key", 1).Value.Float64()
+		i = Int64("key", 1).Value.Int64()
+		i = Int("key", 1).Value.Int64()
+		s = String("key", "foo").Value.String()
+	}))
+	if a != 0 {
+		t.Errorf("got %d allocs, want zero", a)
+	}
+	_ = b
+	_ = f
+	_ = i
+	_ = s
+}
+
+func BenchmarkAttrString(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Int64("key", 1).String()
+		_ = Float64("key", 1).String()
+		_ = Bool("key", true).String()
+		_ = String("key", "foo").String()
+	}
+}
+
+func BenchmarkBool(b *testing.B) {
+	k, v := "bool", true
+	kv := Bool(k, true)
+
+	b.Run("Value", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			boolValue(v)
+		}
+	})
+	b.Run("Attr", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			Bool(k, v)
+		}
+	})
+	b.Run("ToBool", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			kv.Value.Bool()
+		}
+	})
+	b.Run("String", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = kv.Value.String()
+		}
+	})
+}
+
+func BenchmarkString(b *testing.B) {
+	k, v := "string", "foo-bar"
+	kv := String(k, "foo-bar")
+
+	b.Run("Value", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			stringValue(v)
+		}
+	})
+	b.Run("Attr", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			String(k, v)
+		}
+	})
+	b.Run("String", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = kv.Value.String()
+		}
+	})
+}

--- a/trace/attr_value.go
+++ b/trace/attr_value.go
@@ -1,0 +1,224 @@
+package trace
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"unsafe"
+)
+
+// A Value represents an int64, float64, bool, string, or a slice of those
+// types.
+type Value struct {
+	_ [0]func() // disallow ==
+	// num is a taggedNum that stores a value for bool, int64, or float64,
+	// or a tag and length for a string or slice.
+	num taggedNum
+	// data is a pointer to the data for a string or slice, or a marker
+	// pointer for a bool, int64, or float64.
+	data unsafe.Pointer
+}
+
+// taggedNum is a uint64 that stores a value and an optional tag.
+//   - bool: no tag, value is 0 or 1
+//   - float64: no tag, value is math.Float64bits(v)
+//   - int64: no tag, value is int64(v)
+//   - string: tag is kindString, value is len(v)
+//   - bool slice: tag is the kindBoolSlice, value is len(v)
+//   - float64 slice: tag is the kindFloat64Slice, value is len(v)
+//   - int64 slice: tag is the kindInt64Slice, value is len(v)
+//   - string slice: tag is the kindStringSlice, value is len(v)
+type taggedNum struct {
+	n uint64
+}
+
+// tagSize is the number of bits most significant bits used for the tag.
+const tagSize = 8
+
+func newTaggedNum(kind valueKind, num uint64) taggedNum {
+	switch kind {
+	case kindUnset:
+		return taggedNum{n: 0}
+	case kindBool, kindFloat64, kindInt64:
+		return taggedNum{n: num}
+	case kindString, kindBoolSlice, kindFloat64Slice, kindInt64Slice, kindStringSlice:
+		return taggedNum{n: uint64(kind)<<(64-tagSize) | num}
+	default:
+		panic(fmt.Sprintf("unknown value kind: %s", kind))
+	}
+}
+
+// value returns the value of a bool, int64, or float64 value.
+func (t taggedNum) value() uint64 { return t.n }
+
+// kind returns the kind of a string or slice.
+func (t taggedNum) kind() valueKind {
+	return valueKind(t.n >> (64 - tagSize)) //nolint:gosec // safe bit shift
+}
+
+// len returns the length of a string or slice.
+func (t taggedNum) len() uint64 { return t.n << tagSize >> tagSize }
+
+type valueKind uint8
+
+const (
+	kindUnset        valueKind = iota
+	kindBool                   // data == dataKindBool      num == 0 or 1
+	kindFloat64                // data == dataKindFloat64   num == math.Float64bits(v)
+	kindInt64                  // data == dataKindInt64     num == int64(v)
+	kindString                 // data == string data ptr   num == tag & len(v)
+	kindBoolSlice              // data == slice data ptr    num == tag & len(v)
+	kindFloat64Slice           // data == slice data ptr    num == tag & len(v)
+	kindInt64Slice             // data == slice data ptr    num == tag & len(v)
+	kindStringSlice            // data == slice data ptr    num == tag & len(v)
+)
+
+// Marker pointers for the data field of Value. Indicates the kind of data
+// store in Value.num.
+var (
+	dataKindBool    = (unsafe.Pointer)(new(byte)) //nolint:gochecknoglobals // marker pointer
+	dataKindFloat64 = (unsafe.Pointer)(new(byte)) //nolint:gochecknoglobals // marker pointer
+	dataKindInt64   = (unsafe.Pointer)(new(byte)) //nolint:gochecknoglobals // marker pointer
+)
+
+//nolint:gochecknoglobals // string literals for string func
+var valueKindStrings = []string{
+	"Unset",
+	"Bool",
+	"Float64",
+	"Int64",
+	"String",
+	"BoolSlice",
+	"Float64Slice",
+	"Int64Slice",
+	"StringSlice",
+}
+
+func (k valueKind) String() string {
+	return valueKindStrings[k]
+}
+
+// boolValue returns a [Value] for a bool.
+func boolValue(v bool) Value {
+	u := uint64(0)
+	if v {
+		u = 1
+	}
+	return Value{
+		num:  newTaggedNum(kindBool, u),
+		data: dataKindBool,
+	}
+}
+
+// int64Value returns a [Value] for an int64.
+func int64Value(v int64) Value {
+	return Value{
+		num:  newTaggedNum(kindInt64, uint64(v)), //nolint:gosec // safe conversion to uint64
+		data: dataKindInt64,
+	}
+}
+
+// float64Value returns a [Value] for a floating-point number.
+func float64Value(v float64) Value {
+	return Value{
+		num:  newTaggedNum(kindFloat64, math.Float64bits(v)),
+		data: dataKindFloat64,
+	}
+}
+
+// stringValue returns a new [Value] for a string.
+func stringValue(value string) Value {
+	return Value{
+		num:  newTaggedNum(kindString, uint64(len(value))),
+		data: (unsafe.Pointer)(unsafe.StringData(value)),
+	}
+}
+
+func (v Value) kind() valueKind {
+	switch v.data {
+	case dataKindBool:
+		return kindBool
+	case dataKindInt64:
+		return kindInt64
+	case dataKindFloat64:
+		return kindFloat64
+	default:
+		return v.num.kind()
+	}
+}
+
+// Unchecked accessors
+// ===================
+
+func (v Value) uncheckedBool() bool       { return v.num.value() == 1 }
+func (v Value) uncheckedFloat64() float64 { return math.Float64frombits(v.num.value()) }
+func (v Value) uncheckedInt64() int64     { return int64(v.num.value()) } //nolint:gosec // safe conversion to int64
+func (v Value) uncheckedString() string   { return unsafe.String((*byte)(v.data), v.num.len()) }
+
+// Checked accessors
+// =================
+
+// Any returns the value of v as any.
+func (v Value) Any() any {
+	switch k := v.kind(); k {
+	case kindUnset:
+		return nil
+	case kindBool:
+		return v.uncheckedBool()
+	case kindFloat64:
+		return v.uncheckedFloat64()
+	case kindInt64:
+		return v.uncheckedInt64()
+	case kindString:
+		return v.uncheckedString()
+	case kindBoolSlice, kindFloat64Slice, kindInt64Slice, kindStringSlice:
+		panic("unimplemented: Value.Any() for slices")
+	default:
+		panic(fmt.Sprintf("bad kind: %s", k))
+	}
+}
+
+// Bool returns v's value as a bool. It panics if v is not a bool.
+func (v Value) Bool() bool {
+	if g, w := v.kind(), kindBool; g != w {
+		panic(fmt.Sprintf("Value kind is %s, not %s", g, w))
+	}
+	return v.uncheckedBool()
+}
+
+// Int64 returns v's value as an int64. It panics if v is not an int64.
+func (v Value) Int64() int64 {
+	if g, w := v.kind(), kindInt64; g != w {
+		panic(fmt.Sprintf("Value kind is %s, not %s", g, w))
+	}
+	return v.uncheckedInt64()
+}
+
+// Float64 returns v's value as a float64. It panics if v is not a float64.
+func (v Value) Float64() float64 {
+	if g, w := v.kind(), kindFloat64; g != w {
+		panic(fmt.Sprintf("Value kind is %s, not %s", g, w))
+	}
+	return v.uncheckedFloat64()
+}
+
+// String returns Value's value as a string, formatted like [fmt.Sprint].
+// String never panics, even if v is not a string.
+func (v Value) String() string {
+	switch k := v.kind(); k {
+	case kindUnset:
+		return ""
+	case kindBool:
+		return strconv.FormatBool(v.uncheckedBool())
+	case kindInt64:
+		return strconv.FormatInt(v.uncheckedInt64(), 10)
+	case kindFloat64:
+		return strconv.FormatFloat(v.uncheckedFloat64(), 'g', -1, 64)
+	case kindString:
+		return v.uncheckedString()
+	case kindBoolSlice, kindFloat64Slice, kindInt64Slice, kindStringSlice:
+		panic("unimplemented: Value.String() for slices")
+	default:
+		panic(fmt.Sprintf("bad kind: %s", k))
+	}
+}

--- a/trace/attr_value_test.go
+++ b/trace/attr_value_test.go
@@ -1,0 +1,63 @@
+package trace
+
+import (
+	"testing"
+)
+
+func TestKindString(t *testing.T) {
+	if got, want := kindString.String(), "String"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := kindBoolSlice.String(), "BoolSlice"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := kindInt64Slice.String(), "Int64Slice"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := kindFloat64Slice.String(), "Float64Slice"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := kindStringSlice.String(), "StringSlice"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestValueString(t *testing.T) {
+	for _, test := range []struct {
+		v    Value
+		want string
+	}{
+		{int64Value(-3), "-3"},
+		{float64Value(.15), "0.15"},
+		{boolValue(true), "true"},
+		{stringValue("foo"), "foo"},
+	} {
+		if got := test.v.String(); got != test.want {
+			t.Errorf("%#v:\ngot  %q\nwant %q", test.v, got, test.want)
+		}
+	}
+}
+
+func TestValueNoAlloc(t *testing.T) {
+	// Assign values just to make sure the compiler doesn't optimize away the
+	// statements.
+	var (
+		i int64
+		f float64
+		b bool
+		s string
+	)
+	a := int(testing.AllocsPerRun(5, func() {
+		i = int64Value(1).Int64()
+		f = float64Value(1).Float64()
+		b = boolValue(true).Bool()
+		s = stringValue("foo").String()
+	}))
+	if a != 0 {
+		t.Errorf("got %d allocs, want zero", a)
+	}
+	_ = i
+	_ = f
+	_ = b
+	_ = s
+}


### PR DESCRIPTION
Use two words to represent all possible types:

1. bool
2. float64
3. int64
4. string
5. bool slice
6. float64 slice
7. int64 slice
8. string slice

We can simplify the slog.Value implementation because we don't need to support arbitrary types. We can optimize the otel representation by using unsafe tricks from slog.