### PR TITLE
.github: use custom go action

### DIFF
--- a/.github/actions/go_setup/action.yaml
+++ b/.github/actions/go_setup/action.yaml
@@ -1,0 +1,8 @@
+name: Go Setup
+description: Setup Go for testing and compilation.
+runs:
+  using: composite
+  steps:
+    - name: setup Go
+      shell: bash
+      run: ${GITHUB_WORKSPACE}/.github/actions/go_setup/go.sh

--- a/.github/actions/go_setup/action.yaml
+++ b/.github/actions/go_setup/action.yaml
@@ -20,4 +20,4 @@ runs:
     
     - name: setup Go
       shell: bash
-      run: ${GITHUB_ACTION}/go.sh
+      run: ${GITHUB_WORKSPACE}/.github/actions/go_setup/go.sh

--- a/.github/actions/go_setup/action.yaml
+++ b/.github/actions/go_setup/action.yaml
@@ -3,6 +3,8 @@ description: Setup Go for testing and compilation.
 runs:
   using: composite
   steps:
+    # We don't have any deps, so skip go.sum as a hash.
+    # Use the week number to ensure cache is updated weekly.
     - name: Date
       id: date
       run: |
@@ -14,7 +16,7 @@ runs:
       with:
         path: |
           ~/.cache/go-build
-        key: ${{ runner.os }}-${{ runner.arch }}-go-build-${{ hashFiles('go.mod') }}-${{ steps.date.outputs.week-number }}
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ steps.date.outputs.week-number }}
         restore-keys: |
           ${{ runner.os }}-go-
     

--- a/.github/actions/go_setup/action.yaml
+++ b/.github/actions/go_setup/action.yaml
@@ -3,6 +3,21 @@ description: Setup Go for testing and compilation.
 runs:
   using: composite
   steps:
+    - name: Date Week Number
+      id: date-week-number
+      run: |
+        date -u "+%U" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Go build cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-build-${{ hashFiles('go.mod') }}-week-${{ steps.get-date.outputs.date }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    
     - name: setup Go
       shell: bash
-      run: ${GITHUB_WORKSPACE}/.github/actions/go_setup/go.sh
+      run: ${GITHUB_ACTION}/go.sh

--- a/.github/actions/go_setup/action.yaml
+++ b/.github/actions/go_setup/action.yaml
@@ -6,7 +6,7 @@ runs:
     - name: Date
       id: date
       run: |
-        echo "week-number=week-$(date -u "+%U") >> $GITHUB_OUTPUT
+        date -u "+week-number=week-%U" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Go build cache

--- a/.github/actions/go_setup/action.yaml
+++ b/.github/actions/go_setup/action.yaml
@@ -3,10 +3,10 @@ description: Setup Go for testing and compilation.
 runs:
   using: composite
   steps:
-    - name: Date Week Number
-      id: date-week-number
+    - name: Date
+      id: date
       run: |
-        date -u "+%U" >> $GITHUB_OUTPUT
+        echo "week-number=week-$(date -u "+%U") >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Go build cache
@@ -14,7 +14,7 @@ runs:
       with:
         path: |
           ~/.cache/go-build
-        key: ${{ runner.os }}-${{ runner.arch }}-go-build-${{ hashFiles('go.mod') }}-week-${{ steps.get-date.outputs.date }}
+        key: ${{ runner.os }}-${{ runner.arch }}-go-build-${{ hashFiles('go.mod') }}-${{ steps.date.outputs.week-number }}
         restore-keys: |
           ${{ runner.os }}-go-
     

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -20,7 +20,8 @@ mkdir -p "$goroot"
 echo "$goroot/bin" >> "$GITHUB_PATH"
 
 # Download.
-archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
+archive_url="https://github.com/actions/go-versions/releases/download/1.24.5-16210585985/go-1.24.5-linux-x64.tar.gz"
+#archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
 echo "Downloading from: $archive_url"
 curl --fail --silent --show-error --location --write-out "%{stderr}Downloaded in %{time_total} seconds\n" "$archive_url" \
   | tar -xz --strip-components=1 -C "$goroot"

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -2,13 +2,9 @@
 set -euo pipefail
 
 echo '::group::Download Go'
-goroot="./go"
-mkdir -p "$goroot"
-echo "$goroot/bin" >> "$GITHUB_PATH"
 
 # Read Go version from go.mod.
 version=$(grep '^go ' "${GITHUB_WORKSPACE}/go.mod" | awk '{print $2}')
-echo "Using Go version: $version"
 
 # Detect platform and arch.
 platform=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -17,6 +13,11 @@ case "$(uname -m)" in
     aarch64|arm64) arch="arm64" ;;
     *) arch="amd64" ;;  # default fallback
 esac
+echo "Go version: $version, platform: $platform, arch: $arch"
+
+goroot="$RUNNER_TOOL_CACHE/go/$version/$arch"
+mkdir -p "$goroot"
+echo "$goroot/bin" >> "$GITHUB_PATH"
 
 # Download.
 archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
@@ -24,7 +25,6 @@ echo "Downloading from: $archive_url"
 curl --fail --silent --show-error --location --write-out "%{stderr}Downloaded in %{time_total} seconds\n" "$archive_url" \
   | tar -xz --strip-components=1 -C "$goroot"
 
-export PATH="$PATH:$goroot"
-go version
+"$goroot/bin/go" version
 echo '::endgroup::'
 

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo '::group::Download Go'
+go_bin="$HOME/go"
+mkdir -p "$go_bin"
+echo "$go_bin" >> "$GITHUB_PATH"
+
+# Read Go version from go.mod.
+version=$(grep '^go ' "${GITHUB_WORKSPACE}/go.mod" | awk '{print $2}')
+echo "Using Go version: $version"
+
+# Detect platform and arch.
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$(uname -m)" in
+    x86_64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) arch="amd64" ;;  # default fallback
+esac
+
+# Download.
+archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
+echo "Downloading from: $archive_url"
+curl --fail --silent --show-error --location --write-out "%{stderr}Downloaded in %{time_total} seconds\n" "$archive_url" \
+  | tar -xz --strip-components=1 -C "$go_bin" go/bin/go
+
+export PATH="$PATH:$go_bin"
+go version
+echo '::endgroup::'
+

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo '::group::Download Go'
 goroot="./go"
 mkdir -p "$goroot"
-echo "$goroot" >> "$GITHUB_PATH"
+echo "$goroot/bin" >> "$GITHUB_PATH"
 
 # Read Go version from go.mod.
 version=$(grep '^go ' "${GITHUB_WORKSPACE}/go.mod" | awk '{print $2}')

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -15,13 +15,13 @@ case "$(uname -m)" in
 esac
 echo "Go version: $version, platform: $platform, arch: $arch"
 
+# Add to path.
 goroot="$RUNNER_TOOL_CACHE/go/$version/$arch"
 mkdir -p "$goroot"
 echo "$goroot/bin" >> "$GITHUB_PATH"
 
 # Download.
-archive_url="https://github.com/actions/go-versions/releases/download/1.24.5-16210585985/go-1.24.5-linux-x64.tar.gz"
-#archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
+archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
 echo "Downloading from: $archive_url"
 curl --fail --silent --show-error --location --write-out "%{stderr}Downloaded in %{time_total} seconds\n" "$archive_url" \
   | tar -xz --strip-components=1 -C "$goroot"

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -22,7 +22,7 @@ esac
 archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
 echo "Downloading from: $archive_url"
 curl --fail --silent --show-error --location --write-out "%{stderr}Downloaded in %{time_total} seconds\n" "$archive_url" \
-  | tar -xz --strip-components=1 -C "$go_bin" go/bin/go
+  | tar -xz --strip-components=2 -C "$go_bin" go/bin/go
 
 export PATH="$PATH:$go_bin"
 go version

--- a/.github/actions/go_setup/go.sh
+++ b/.github/actions/go_setup/go.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 echo '::group::Download Go'
-go_bin="$HOME/go"
-mkdir -p "$go_bin"
-echo "$go_bin" >> "$GITHUB_PATH"
+goroot="./go"
+mkdir -p "$goroot"
+echo "$goroot" >> "$GITHUB_PATH"
 
 # Read Go version from go.mod.
 version=$(grep '^go ' "${GITHUB_WORKSPACE}/go.mod" | awk '{print $2}')
@@ -22,9 +22,9 @@ esac
 archive_url="https://go.dev/dl/go${version}.${platform}-${arch}.tar.gz"
 echo "Downloading from: $archive_url"
 curl --fail --silent --show-error --location --write-out "%{stderr}Downloaded in %{time_total} seconds\n" "$archive_url" \
-  | tar -xz --strip-components=2 -C "$go_bin" go/bin/go
+  | tar -xz --strip-components=1 -C "$goroot"
 
-export PATH="$PATH:$go_bin"
+export PATH="$PATH:$goroot"
 go version
 echo '::endgroup::'
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,9 +7,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: ./.github/actions/go_setup
-
       - name: Run
         uses: golangci/golangci-lint-action@v7
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,9 +8,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+        uses: ./.github/actions/go_setup
 
       - name: Run
         uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
                   file=$(echo "$line" | cut -d: -f1)
                   func=$(echo "$line" | cut -d: -f2 | sed 's/func \([^(]*\).*/\1/')
                   dir=$(dirname "$file")
-                  printf '{"function":"%s","directory":"%s"},' "$func" "$dir"
+                  printf '{"function":"%s","directory":"./%s"},' "$func" "$dir"
                 done
           )
           elems="[${fuzz_data%,}]" # trim trailing comma

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,37 @@ jobs:
 
       - run: go test -race ./...
 
-  fuzz:
+  discover-fuzz:
     runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.find-fuzz.outputs.targets }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Find fuzz functions
+        id: find-fuzz
+        run: |
+          # Find all fuzz functions and their directories.
+          fuzz_data=$(
+            find . -name "*.go" -type f -exec grep -H "func Fuzz" {} \; \
+              | sed 's|^\./||' \
+              | while read line; do
+                  file=$(echo "$line" | cut -d: -f1)
+                  func=$(echo "$line" | cut -d: -f2 | sed 's/func \([^(]*\).*/\1/')
+                  dir=$(dirname "$file")
+                  echo "{\"function\":\"$func\",\"directory\":\"./$dir\"},"
+                done
+          )
+          elems="[${fuzz_data%,}]" # trim trailing comma
+          echo "targets=$elems" >> $GITHUB_OUTPUT
+
+  fuzz:
+    needs: discover-fuzz
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fuzz: ${{ fromJSON(needs.discover-fuzz.outputs.targets) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,8 +50,5 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/go_setup
 
-      - name: FuzzLifecycle
-        run: go test -fuzztime 15s -fuzz=FuzzLifecycle ./trace
-
-      - name: FuzzParseState
-        run: go test -fuzztime 15s -fuzz=FuzzParseState ./trace
+      - name: Run ${{ matrix.fuzz.function }}
+        run: go test -fuzztime 15s -fuzz=${{ matrix.fuzz.function }} ${{ matrix.fuzz.directory }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,12 +26,11 @@ jobs:
           # Find all fuzz functions and their directories.
           fuzz_data=$(
             find . -name "*.go" -type f -exec grep -H "func Fuzz" {} \; \
-              | sed 's|^\./||' \
               | while read line; do
                   file=$(echo "$line" | cut -d: -f1)
                   func=$(echo "$line" | cut -d: -f2 | sed 's/func \([^(]*\).*/\1/')
                   dir=$(dirname "$file")
-                  printf '{"function":"%s","directory":"./%s"},' "$func" "$dir"
+                  printf '{"function":"%s","directory":"%s"},' "$func" "$dir"
                 done
           )
           elems="[${fuzz_data%,}]" # trim trailing comma
@@ -51,4 +50,4 @@ jobs:
         uses: ./.github/actions/go_setup
 
       - name: Run ${{ matrix.fuzz.function }}
-        run: go test -fuzztime 15s -fuzz=${{ matrix.fuzz.function }} ${{ matrix.fuzz.directory }}
+        run: go test -fuzztime 25s -fuzz=${{ matrix.fuzz.function }} ${{ matrix.fuzz.directory }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+        uses: ./.github/actions/go_setup
 
       - run: go test -race ./...
 
@@ -21,8 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+        uses: ./.github/actions/go_setup
 
-      - run: go test -fuzztime 15s -fuzz=Fuzz ./trace
+      - name: FuzzLifecycle
+        run: go test -fuzztime 15s -fuzz=FuzzLifecycle ./trace
+
+      - name: FuzzParseState
+        run: go test -fuzztime 15s -fuzz=FuzzParseState ./trace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
           echo "targets=$elems" >> $GITHUB_OUTPUT
 
   fuzz:
+    name: ${{ matrix.fuzz.function }}
     needs: discover-fuzz
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
                   file=$(echo "$line" | cut -d: -f1)
                   func=$(echo "$line" | cut -d: -f2 | sed 's/func \([^(]*\).*/\1/')
                   dir=$(dirname "$file")
-                  echo "{\"function\":\"$func\",\"directory\":\"./$dir\"},"
+                  printf '{"function":"%s","directory":"%s"},' "$func" "$dir"
                 done
           )
           elems="[${fuzz_data%,}]" # trim trailing comma


### PR DESCRIPTION
The official setup-go action spends the majority of time caching the go binary and attempting to cache the go.sum entry.